### PR TITLE
Bump README repo version

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ the pryright output is difficult to read, this project wraps it and shows it in 
 
 ```yaml
 - repo: https://github.com/northisup/pyright-pretty
-  rev: v0.1.0
+  rev: v0.1.3
   hooks:
   - id: pyright-pretty
 ```
@@ -15,7 +15,7 @@ if your `pyproject.toml` is not in the root of your repo, use `args` to specify 
 
 ```yaml
 - repo: https://github.com/northisup/pyright-pretty
-  rev: v0.1.0
+  rev: v0.1.3
   hooks:
   - id: pyright-pretty
     name: Python type checking [project-one]


### PR DESCRIPTION
My bad, the setup from the README was outdated. 

Updating to the latest version (v0.1.3) appears to have resolved the issue, as the previous error seems to have been caused by a formatting issue.

closes #1 